### PR TITLE
Upgrade `bitfinex-api-node` to 2.0.0-beta.1 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@ This Node JS script executes a long/short order when a trigger price is reached,
 You will need to download and install the following:
 
 * nodeJS: [https://nodejs.org/en/download/](https://nodejs.org/en/download/)
-* Git: [Git for Windows](https://gitforwindows.org/) | [Git for Mac](https://sourceforge.net/projects/git-osx-installer/files/latest/download?source=files) | [Git for Linux](https://git-scm.com/download/linux)
 
 To install and use the script:
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "homepage": "https://github.com/cryptomius/Bitfinex-Auto-Stop-121-Scale-Out#readme",
   "dependencies": {
     "bignumber.js": "^6.0.0",
-    "bitfinex-api-node": "bitfinexcom/bitfinex-api-node",
+    "bitfinex-api-node": "2.0.0-beta.1",
     "crc-32": "^1.2.0"
   }
 }


### PR DESCRIPTION
Set `bitfinex-api-node` dependency to 2.0.0-beta.1 release.
Remove Git from setup instructions. Git is no longer required now that a release version of `bitfinex-api-node` is used.