### PR TITLE
Add npm scripts for common trade types

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,15 @@
   "name": "bitfinex-auto-stop-121-scale-out",
   "version": "1.6.0",
   "main": "121ScaleOut.js",
+  "scripts": {
+    "121": "node 121ScaleOut.js",
+    "cradle-long": "node 121ScaleOut.js",
+    "cradle-short": "node 121ScaleOut.js -S",
+    "breakout-long": "node 121ScaleOut.js",
+    "breakout-short": "node 121ScaleOut.js -S",
+    "booster-long": "node 121ScaleOut.js -l",
+    "booster-short": "node 121ScaleOut.js -l -S"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/cryptomius/Bitfinex-Auto-Stop-121-Scale-Out.git"


### PR DESCRIPTION
Add npm scripts with default options covering common trade types.

Usage:
`npm run <trade-type> -- [options]`

Examples:
`npm run cradle-short -- -p BTCUSD -a 0.004 -e 9000 -s 10000`
Places a cradle short (ie. market stop entry order (default) with short position *-S*).

`npm run booster-short -- -p BTCUSD -a 0.004 -e 9000 -s 10000`
Places a booster short (ie. limit entry order *-l* with short position *-S*).

Note: `--` delimiter before options is required by npm-run-script:
https://docs.npmjs.com/cli/run-script